### PR TITLE
feat(deps): update deps to lastest and use object spread

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Target node version should match the version used by Atom, this ensures that
 # ESLint extensions in Atom can execute these settings
-FROM node:7.9-alpine
+FROM node:8.9-alpine
 
 WORKDIR /usr/src/app
 

--- a/index.js
+++ b/index.js
@@ -37,34 +37,28 @@ module.exports = {
       : { node: { extensions: ['.js', '.mjs', '.json'] } }
   },
 
-  rules: Object.assign(
-    {
-      // --- 🌬 Flow
-      // See: https://github.com/gajus/eslint-plugin-flowtype
-      'flowtype/define-flow-type': 'warn',
-      'flowtype/require-valid-file-annotation': 'warn',
-      'flowtype/use-flow-type': 'warn',
+  rules: {
+    // --- 🌬 Flow
+    // See: https://github.com/gajus/eslint-plugin-flowtype
+    'flowtype/define-flow-type': 'warn',
+    'flowtype/require-valid-file-annotation': 'warn',
+    'flowtype/use-flow-type': 'warn',
 
-      // --- ⬆️ Updates/Enhancements
-      // Don't enforce .jsx file extension, it doesn't provide a clear benefit and
-      // often requires addl configs on other tooling, do less ¯\_(ツ)_/¯
-      'react/jsx-filename-extension': 'off',
-      // Don't enforce props destructuring, it's cumbersome when only a single
-      // prop is needed, and consistent destructuring provides no real benefit
-      'react/destructuring-assignment': 'off',
-      // Include .mjs file extension in list of file that shouldn't use ext
-      'import/extensions': [
-        'error',
-        'always',
-        { js: 'never', jsx: 'never', mjs: 'never' }
-      ],
+    // --- ⬆️ Updates/Enhancements
+    // Don't enforce .jsx file extension, it doesn't provide a clear benefit and
+    // often requires addl configs on other tooling, do less ¯\_(ツ)_/¯
+    'react/jsx-filename-extension': 'off',
+    // Don't enforce props destructuring, it's cumbersome when only a single
+    // prop is needed, and consistent destructuring provides no real benefit
+    'react/destructuring-assignment': 'off',
+    // Include .mjs file extension in list of file that shouldn't use ext
+    'import/extensions': ['error', 'always', { js: 'never', jsx: 'never', mjs: 'never' }],
 
-      // --- 🐛 Bugs
+    // --- 🐛 Bugs
 
-      // Class ordering currently doesn't support class property syntax, which is 🙅
-      // Update on: https://github.com/yannickcr/eslint-plugin-react/pull/685
-      'react/sort-comp': 'off'
-    },
+    // Class ordering currently doesn't support class property syntax, which is 🙅
+    // Update on: https://github.com/yannickcr/eslint-plugin-react/pull/685
+    'react/sort-comp': 'off',
 
     // 🌍 Environment adjustments
     // ---------------------------------------------------------------------------
@@ -76,7 +70,7 @@ module.exports = {
      * (especially when using webpack dev server hooked into the errors overlay
      * 😉)
      */
-    NODE_ENV === 'test'
+    ...(NODE_ENV === 'test'
       ? {
           // Validate formatting is correct in test,prod,etc.
           'prettier/prettier': 'error'
@@ -107,6 +101,6 @@ module.exports = {
           'react/self-closing-comp': 'warn',
 
           'import/first': 'warn'
-        }
-  )
+        })
+  }
 }

--- a/package.json
+++ b/package.json
@@ -24,21 +24,21 @@
     "format": "prettier --write \"*.{js,md}\""
   },
   "dependencies": {
-    "babel-eslint": "~8.2.6",
-    "eslint": "~5.1.0",
-    "eslint-config-airbnb": "17.0.0",
-    "eslint-config-prettier": "~2.9.0",
+    "babel-eslint": "~9.0.0",
+    "eslint": "~5.4.0",
+    "eslint-config-airbnb": "17.1.0",
+    "eslint-config-prettier": "~3.0.1",
     "eslint-plugin-flowtype": "~2.50.0",
-    "eslint-plugin-import": "~2.13.0",
+    "eslint-plugin-import": "~2.14.0",
     "eslint-plugin-jsx-a11y": "~6.1.1",
     "eslint-plugin-prettier": "~2.6.2",
-    "eslint-plugin-react": "~7.10.0"
+    "eslint-plugin-react": "~7.11.1"
   },
   "devDependencies": {
     "commitizen": "^2.10.1",
     "cz-customizable": "^5.2.0",
-    "prettier": "^1.13.7",
-    "semantic-release": "^15.8.1"
+    "prettier": "^1.14.2",
+    "semantic-release": "^15.9.12"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
VSCode and Atom both have updated to Node 8.9.3, allowing object spread 🎉