### PR TITLE
Fix: Enforce sort default props rule ✓

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "license": "ISC",
   "scripts": {
-    "test": "NODE_ENV=test eslint *.js",
+    "test": "NODE_ENV=test eslint --format=pretty *.js src",
     "format": "prettier --write '*.{md,js,json}' '{.github,src}/**/*.{md,js,json}'"
   },
   "dependencies": {

--- a/src/dev-rule-overrides.js
+++ b/src/dev-rule-overrides.js
@@ -35,6 +35,7 @@ module.exports = project => {
           'react/default-props-match-prop-types': 'warn',
           'react/forbid-prop-types': 'warn',
           'react/jsx-boolean-value': 'warn',
+          'react/jsx-sort-default-props': 'warn',
           'react/no-multi-comp': 'warn',
           'react/no-unescaped-entities': 'warn',
           'react/no-unused-prop-types': 'warn',

--- a/src/rules/react.js
+++ b/src/rules/react.js
@@ -146,15 +146,6 @@ module.exports = {
     },
   ],
 
-  // Enforce defaultProps declarations alphabetical sorting
-  // https://github.com/yannickcr/eslint-plugin-react/blob/843d71a432baf0f01f598d7cf1eea75ad6896e4b/docs/rules/jsx-sort-default-props.md
-  'react/jsx-sort-default-props': [
-    'off',
-    {
-      ignoreCase: true,
-    },
-  ],
-
   // Prevent React to be incorrectly marked as unused
   // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-uses-react.md
   'react/jsx-uses-react': ['error'],


### PR DESCRIPTION
Rule `react/jsx-sort-default-props` had a duplicate key that was overriding it to off.